### PR TITLE
strip flow types when transpiling

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,5 +1,6 @@
 {
   "plugins": [
     "transform-es2015-modules-commonjs",
+    "transform-flow-strip-types"
   ]
 }

--- a/.babelrc
+++ b/.babelrc
@@ -1,4 +1,7 @@
 {
+  "presets": [
+    "babel-preset-es2015"
+  ],
   "plugins": [
     "transform-es2015-modules-commonjs",
     "transform-flow-strip-types"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: node_js
 
 node_js:
+  - "4"
   - "6"

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
   ],
   "devDependencies": {
     "babel-cli": "^6.9.0",
+    "babel-register": "^6.16.3",
     "babel-plugin-transform-es2015-modules-commonjs": "^6.11.5",
     "babel-plugin-transform-flow-strip-types": "^6.14.0",
     "babel-preset-es2015": "^6.16.0",

--- a/package.json
+++ b/package.json
@@ -35,5 +35,8 @@
     "webpack",
     "remove"
   ],
-  "license": "MIT"
+  "license": "MIT",
+  "dependencies": {
+    "babel-plugin-transform-flow-strip-types": "^6.14.0"
+  }
 }

--- a/package.json
+++ b/package.json
@@ -19,6 +19,8 @@
   "devDependencies": {
     "babel-cli": "^6.9.0",
     "babel-plugin-transform-es2015-modules-commonjs": "^6.11.5",
+    "babel-plugin-transform-flow-strip-types": "^6.14.0",
+    "babel-preset-es2015": "^6.16.0",
     "mocha": "^3.0.0"
   },
   "scripts": {
@@ -35,8 +37,5 @@
     "webpack",
     "remove"
   ],
-  "license": "MIT",
-  "dependencies": {
-    "babel-plugin-transform-flow-strip-types": "^6.14.0"
-  }
+  "license": "MIT"
 }


### PR DESCRIPTION
There is flow type syntax in module, node4 does not understand it so it's necessary to transpile it using flow-strip-types babel plugin
